### PR TITLE
Fix: Remove special nav-link style from admin buttons

### DIFF
--- a/post/templates/post/base.html
+++ b/post/templates/post/base.html
@@ -295,8 +295,8 @@
                     <li><a href="{% url 'tienda:cuenta_dashboard' %}" class="nav-link-special">Mi Cuenta</a></li>
                     {# --- INICIO BOTONES DE ADMINISTRADOR --- #}
                     {% if user.cliente.rol == 'administrador' %}
-                        <li><a href="{% url 'tienda:admin_agregar_producto' %}" class="nav-link-special btn btn-sm btn-warning">Añadir Producto</a></li>
-                        <li><a href="{% url 'tienda:admin_agregar_promocion' %}" class="nav-link-special btn btn-sm btn-info">Añadir Promoción</a></li>
+                        <li><a href="{% url 'tienda:admin_agregar_producto' %}" class="btn btn-sm btn-warning">Añadir Producto</a></li>
+                        <li><a href="{% url 'tienda:admin_agregar_promocion' %}" class="btn btn-sm btn-info">Añadir Promoción</a></li>
                     {% endif %}
                     {# --- FIN BOTONES DE ADMINISTRADOR --- #}
                     <li>


### PR DESCRIPTION
The admin buttons "Añadir Producto" and "Añadir Promoción" in the navigation bar were unintentionally displaying the same special hover effect (a golden underline) as regular navigation links.

This commit removes the `nav-link-special` class from these two admin buttons in the `post/templates/post/base.html` template. The buttons now retain their standard button styling (from Bootstrap classes like `btn`, `btn-sm`, `btn-warning`, `btn-info`) but no longer show the golden underline effect.

Other navigation links that use the `nav-link-special` class will continue to display the effect as intended. The visibility of the admin buttons remains restricted to users with the 'administrador' role.