### PR TITLE
Configure media file handling for product images

### DIFF
--- a/alternissi_project/settings.py
+++ b/alternissi_project/settings.py
@@ -118,6 +118,10 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+# Media files (Uploads)
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
This commit introduces the necessary settings for Django to manage user-uploaded media files, specifically product images.

- Added `MEDIA_URL` and `MEDIA_ROOT` to `alternissi_project/settings.py`.
  - `MEDIA_URL` is set to '/media/'.
  - `MEDIA_ROOT` is set to `BASE_DIR / 'media'`.

This change enables the serving of product images uploaded via the Django admin interface, which was already configured to allow image uploads for products. The existing URL patterns in `alternissi_project/urls.py` will serve these media files when `DEBUG` is True.