### PR TITLE
Okay, I've updated the "Productos Destacados" section on the homepage.

### DIFF
--- a/post/templates/post/inicio.html
+++ b/post/templates/post/inicio.html
@@ -11,36 +11,22 @@
 </section>
 
 <section class="productos-destacados">
-    <h2>Productos Destacados</h2>
+    <h2>Nuestros Productos Destacados</h2>
     {% if productos_destacados %}
-        <div class="product-grid">
-            {% for producto in productos_destacados %}
-                <div class="product-card">
-                    {% if producto.imagenes.first %}
-                        <a href="{{ producto.get_absolute_url }}">
-                            <img src="{{ producto.imagenes.first.imagen.url }}" alt="{{ producto.imagenes.first.alt_text|default:producto.nombre }}">
-                        </a>
-                    {% else %}
-                        <a href="{{ producto.get_absolute_url }}">
-                            <img src="{% static 'post/images/placeholder.png' %}" alt="Imagen no disponible">
-                        </a>
-                    {% endif %}
-                    <h3><a href="{{ producto.get_absolute_url }}">{{ producto.nombre }}</a></h3>
-                    <p class="precio">
-                        {% if producto.tiene_descuento %}
-                            <span class="precio-original">{{ producto.precio|floatformat:2 }} {{moneda_simbolo|default:'$'}}</span>
-                            <span class="precio-descuento">{{ producto.precio_actual|floatformat:2 }} {{moneda_simbolo|default:'$'}}</span>
-                        {% else %}
-                            {{ producto.precio_actual|floatformat:2 }} {{moneda_simbolo|default:'$'}}
-                        {% endif %}
-                    </p>
-                    <a href="{{ producto.get_absolute_url }}" class="btn-secondary">Ver Detalles</a>
-                </div>
-            {% endfor %}
-        </div>
-    {% else %}
-        <p>No hay productos destacados en este momento.</p>
-    {% endif %}
+    <ul>
+        {% for producto in productos_destacados %}
+            <li>
+                {% if producto.imagenes.first %}
+                    {{ producto.imagenes.first.alt_text|default:producto.nombre }}
+                {% else %}
+                    {{ producto.nombre }}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p>No hay productos destacados en este momento.</p>
+{% endif %}
 </section>
 
 <section class="productos-nuevos">


### PR DESCRIPTION
Here's what changed in `post/templates/post/inicio.html`:
- The section title changed from "Productos Destacados" to "Nuestros Productos Destacados".
- The display of featured products was simplified to show a list with the product name or the alt text of its main image, instead of the detailed card structure.

I also confirmed that the `InicioTiendaView` view is still correctly providing the `productos_destacados` variable to the template. These changes address your request to revert the carousel's appearance to an earlier, simpler version with a specific title.