### PR TITLE
Fix NoReverseMatch for pagina_info in footer

### DIFF
--- a/post/templates/post/base.html
+++ b/post/templates/post/base.html
@@ -63,9 +63,9 @@
         <div class="container">
             <p>&copy; {% now "Y" %} Alternissi. Todos los derechos reservados.</p>
             <ul>
-                <li><a href="{% url 'tienda:pagina_info' 'politica-privacidad' %}">Política de Privacidad</a></li>
-                <li><a href="{% url 'tienda:pagina_info' 'terminos-condiciones' %}">Términos y Condiciones</a></li>
-                <li><a href="{% url 'tienda:pagina_info' 'sobre-nosotros' %}">Sobre Nosotros</a></li>
+                <li><a href="{% url 'tienda:politica_privacidad' %}">Política de Privacidad</a></li>
+                <li><a href="{% url 'tienda:terminos_condiciones' %}">Términos y Condiciones</a></li>
+                <li><a href="{% url 'tienda:sobre_nosotros' %}">Sobre Nosotros</a></li>
             </ul>
         </div>
     </footer>

--- a/post/urls.py
+++ b/post/urls.py
@@ -90,6 +90,7 @@ urlpatterns = [
     path('contacto/', views.PaginaContactoView.as_view(), name='contacto'),
     path('politica-privacidad/', views.PoliticaPrivacidadView.as_view(), name='politica_privacidad'),
     path('terminos-condiciones/', views.TerminosCondicionesView.as_view(), name='terminos_condiciones'),
+    path('sobre-nosotros/', views.SobreNosotrosView.as_view(), name='sobre_nosotros'),
 
     # --- URLs de Administración ---
     path('admin/productos/nuevo/', views.agregar_producto_admin_view, name='admin_agregar_producto'),

--- a/post/views.py
+++ b/post/views.py
@@ -827,6 +827,19 @@ class TerminosCondicionesView(PaginaEstaticaView):
         context['contenido'] = context['config'].terminos_condiciones if context['config'] else ""
         return context
 
+class SobreNosotrosView(PaginaEstaticaView):
+    template_name = 'post/pagina_info.html'
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['titulo'] = 'Sobre Nosotros'
+        # Attempt to get content from a field like 'sobre_nosotros_info' or 'sobre_nosotros'
+        # Provide a default if the field doesn't exist or config is None
+        if context['config']:
+            context['contenido'] = getattr(context['config'], 'sobre_nosotros_info', "Información sobre nosotros no disponible.")
+        else:
+            context['contenido'] = "Información sobre nosotros no disponible."
+        return context
+
 # --- Vistas de Administración (Protegidas) ---
 @user_passes_test(lambda u: u.is_staff)
 @login_required


### PR DESCRIPTION
- Corrected URL tags in base.html to use existing named URLs for privacy policy and terms.
- Added SobreNosotrosView and a corresponding URL pattern 'sobre_nosotros' to handle the 'Sobre Nosotros' link.
- The 'Sobre Nosotros' page will display content from ConfiguracionTienda.sobre_nosotros_info if the field exists, otherwise a default message.