### PR TITLE
Fix: Resolve URL conflict for custom admin login

### DIFF
--- a/post/urls.py
+++ b/post/urls.py
@@ -95,7 +95,7 @@ urlpatterns = [
     path('sobre-nosotros/', views.SobreNosotrosView.as_view(), name='sobre_nosotros'),
 
     # --- URLs de Administración ---
-    path('admin/login/', views.admin_login_view, name='admin_login'),
-    path('admin/productos/nuevo/', views.agregar_producto_admin_view, name='admin_agregar_producto'),
-    path('admin/promociones/nuevo/', views.agregar_promocion_admin_view, name='admin_agregar_promocion'),
+    path('gestion/login/', views.admin_login_view, name='admin_login'),
+    path('gestion/productos/nuevo/', views.agregar_producto_admin_view, name='admin_agregar_producto'),
+    path('gestion/promociones/nuevo/', views.agregar_promocion_admin_view, name='admin_agregar_promocion'),
 ]


### PR DESCRIPTION
The custom admin URL at `admin/login/` was shadowed by the standard Django admin URLs, which are included under the `/admin/` path. This made the custom admin login view unreachable.

This commit resolves the conflict by moving the custom admin URLs to a new, non-conflicting path prefix: `/gestion/`.

The following URL paths were changed in `post/urls.py`:
- `admin/login/` -> `gestion/login/`
- `admin/productos/nuevo/` -> `gestion/productos/nuevo/`
- `admin/promociones/nuevo/` -> `gestion/promociones/nuevo/`

A thorough search was conducted to ensure that there were no hardcoded dependencies on the old URL paths, so this change should not break any existing functionality.