### PR TITLE
feat: Add favicon below Alternissi logo

### DIFF
--- a/post/templates/post/base.html
+++ b/post/templates/post/base.html
@@ -17,6 +17,7 @@
             <nav>
                 <div class="logo">
                     <a href="{% url 'tienda:inicio' %}"><h1>Alternissi</h1></a>
+                    <img src="/media/marcas/favicon.jpg" alt="Alternissi logo" style="width: 50px; height: auto; display: block; margin: 10px auto 0;">
                 </div>
                 <button class="nav-toggle" aria-label="toggle navigation">
                     <span class="hamburger"></span>


### PR DESCRIPTION
This commit adds the `favicon.jpg` image directly below the "Alternissi" text in the header of the website.

The `post/templates/post/base.html` file was modified to include an `<img>` tag after the `<h1>` containing the site's name. Inline styles have been added to control the size and positioning of the image.